### PR TITLE
fix: 스터디 카드 목록 조회 api 개선점 반영

### DIFF
--- a/src/api/study/createStudyApi/createStudyApi.ts
+++ b/src/api/study/createStudyApi/createStudyApi.ts
@@ -2,6 +2,7 @@
 
 import createServerInstance from '../../axiosServerInstance';
 import { CreateStudyRequest, CreateStudyResponse } from './types';
+import {StudyType} from "@/types/study/study";
 
 /**
  * 서버에서 새 스터디 생성 API
@@ -18,7 +19,7 @@ export const createStudyServer = async (
   content: string,
   maxParticipants: number,
   dueDate: string,
-  category: 'CERTIFICATE' | 'HOBBY',
+  category: StudyType,
   isOnline: boolean
 ): Promise<void> => {
   const requestData: CreateStudyRequest = {

--- a/src/api/study/createStudyApi/createStudyClientApi.ts
+++ b/src/api/study/createStudyApi/createStudyClientApi.ts
@@ -1,5 +1,6 @@
 import api from '../../axiosInstance';
 import { CreateStudyRequest, CreateStudyResponse } from './types';
+import {StudyType} from "@/types/study/study";
 
 /**
  * 새 스터디 생성 API
@@ -16,7 +17,7 @@ export const createStudy = async (
   content: string,
   maxParticipants: number,
   dueDate: string,
-  category: 'CERTIFICATE' | 'HOBBY',
+  category: StudyType,
   isOnline: boolean
 ): Promise<void> => {
   const requestData: CreateStudyRequest = {

--- a/src/api/study/createStudyApi/types.ts
+++ b/src/api/study/createStudyApi/types.ts
@@ -1,9 +1,11 @@
+import {StudyType} from "@/types/study/study";
+
 export interface CreateStudyRequest {
   title: string;
   content: string;
   maxParticipants: number;
   dueDate: string;
-  category: 'CERTIFICATE' | 'HOBBY';
+  category: StudyType;
   isOnline: boolean;
 }
 

--- a/src/api/study/getStudyApi/types.ts
+++ b/src/api/study/getStudyApi/types.ts
@@ -34,14 +34,16 @@ export interface StudyCardItem {
   title: string;
   content: string;
   userProfile: UserProfile;
-  type: StudyType;
+  maxParticipants: number;    // 최대 참여 인원
+  category: StudyType;        // 스터디 타입 (자격증, 취미)
   createdTime: string;
   updatedTime: string;
   dueDate: string;
   online: boolean;
-  available: boolean;
-  registered: boolean;
-  participated: boolean;
+  available: boolean;         // 모집 중(true) / 모집 완료(false)
+  participantIds: string[];   // 참여자 ID 목록
+  participantNames: string[]; // 참여자 이름 목록
+  participated: boolean;      // 참여 여부
   mine: boolean;
 }
 

--- a/src/app/study/StudyClient.tsx
+++ b/src/app/study/StudyClient.tsx
@@ -1,93 +1,82 @@
 'use client';
 
-import { useState, useEffect, useRef, useCallback } from 'react';
-import { useRouter } from 'next/navigation';
-import { useSelector } from 'react-redux';
+import {useCallback, useEffect, useState} from 'react';
+import {useRouter} from 'next/navigation';
+import {useSelector} from 'react-redux';
 import {
-    MdFilterList,
     MdAccessTime,
+    MdCalendarToday,
     MdCheck,
     MdClear,
-    MdPerson,
-    MdCalendarToday,
     MdClose,
-    MdInfo,
+    MdDelete,
     MdEdit,
-    MdCampaign,
-    MdFilterAlt,
+    MdFilterList,
+    MdFirstPage,
+    MdInfo,
     MdKeyboardArrowLeft,
     MdKeyboardArrowRight,
-    MdFirstPage,
     MdLastPage,
-    MdDelete
+    MdPerson
 } from 'react-icons/md';
 
-import { useToast } from '@/hooks/useToast';
-import { ToastContainer } from '@/components/Toast';
+import {useToast} from '@/hooks/useToast';
+import {ToastContainer} from '@/components/Toast';
 import StudyModal from './StudyModal';
-import StudyCreateModal, { StudyFormData } from '@/components/StudyCreateModal/StudyCreateModal';
-import { formatDate } from '@/utils/dateUtils';
-import { getStudies } from '@/api/study/getStudyApi';
-import { adaptStudyCardToStudy } from '@/utils/studyAdapter';
-import { deleteStudy } from '@/api/study/deleteStudyApi';
-import { applyStudy } from '@/api/study/applyStudyApi';
+import StudyCreateModal, {StudyFormData} from '@/components/StudyCreateModal/StudyCreateModal';
+import {formatDate} from '@/utils/dateUtils';
+import {getStudies} from '@/api/study/getStudyApi';
+import {adaptStudyCardToStudy} from '@/utils/studyAdapter';
+import {deleteStudy} from '@/api/study/deleteStudyApi';
+import {applyStudy} from '@/api/study/applyStudyApi';
 
 import PageHeader from '@/components/PageHeader/PageHeader';
 import AnnouncementBox from '@/components/AnnouncementBox/AnnouncementBox';
 import FloatingButton from '@/components/FloatingButton/FloatingButton';
 
 import {
-    StudyContainer,
-    StudyContentWrapper,
-    MainContent,
-    StudyListContainer,
-    StudyCard,
-    CardHeader,
-    CardBody,
-    CardFooter,
-    StatusTag,
-    TagsContainer,
-    StudyTypeTag,
-    OnlineTag,
-    ProfileSection,
-    ProfileImage,
-    UserInfo,
-    UserName,
-    StudyTitle,
-    StudyInfoContainer,
-    MemberCount,
-    MemberCountValue,
-    Deadline,
-    DeadlineValue,
-    LoadingContainer,
-    LoadingSpinner,
-    EmptyStateText,
-    ErrorText,
-    colors,
-    StatusIndicator,
     ApplyBadge,
     CardActions,
-    ViewDetailsButton,
+    CardBody,
+    CardFooter,
+    CardHeader,
+    ClearFiltersButton,
+    colors,
+    Deadline,
+    DeadlineValue,
+    DeleteButton,
+    EmptyStateText,
+    ErrorText,
     FilterButton,
     FilterContainer,
-    FilterBadge,
     FilterDivider,
-    ClearFiltersButton,
-    PaginationContainer,
-    PaginationButton,
-    PaginationInfo,
+    LoadingContainer,
+    LoadingSpinner,
+    MainContent,
+    MemberCount,
+    OnlineTag,
     PageNumbersContainer,
+    PaginationButton,
+    PaginationContainer,
     PaginationEllipsis,
-    DeleteButton, // 추가된 DeleteButton
+    ProfileImage,
+    ProfileSection,
+    StatusIndicator,
+    StatusTag,
+    StudyCard,
+    StudyContainer,
+    StudyContentWrapper,
+    StudyInfoContainer,
+    StudyListContainer,
+    StudyTitle,
+    StudyTypeTag,
+    TagsContainer,
+    UserInfo,
+    UserName,
+    ViewDetailsButton,
 } from './page.style';
 
-import {
-    Study,
-    StudyStatusType,
-    StudyFilterStatusType,
-    StudyFilters,
-    StudyType, parseStudyType, studyTypeToApiCategory
-} from '@/types/study/study';
+import {Study, StudyFilters, StudyFilterStatusType, StudyStatusType, StudyType} from '@/types/study/study';
 import {createStudy} from "@/api/study/createStudyApi";
 import {cancelStudy} from "@/api/study/cancelStudyApi";
 
@@ -385,7 +374,6 @@ const StudyClient = () => {
                     prevStudies.map(study =>
                         study.id === studyId ? {
                             ...study,
-                            isApplied: true,
                             participated: true,
                             currentMembers: study.currentMembers + 1
                         } : study
@@ -493,13 +481,12 @@ const StudyClient = () => {
 
     // 새 스터디 저장 핸들러
     const handleSaveStudy = useCallback(async (studyData: StudyFormData) => {
-        const apiCategory = studyTypeToApiCategory(studyData.type);
         await createStudy(
             studyData.title,
-            studyData.description,
+            studyData.content,
             studyData.totalMembers,
             studyData.deadline,
-            apiCategory,
+            studyData.type,
             studyData.isOnline
         );
 
@@ -604,8 +591,8 @@ const StudyClient = () => {
                                         </StudyInfoContainer>
                                     </CardBody>
                                     <CardFooter>
-                                        <StatusIndicator isApplied={study.isApplied} status={study.status}>
-                                            <ApplyBadge isApplied={study.isApplied} status={study.status}>
+                                        <StatusIndicator isApplied={study.participated} status={study.status}>
+                                            <ApplyBadge isApplied={study.participated} status={study.status}>
                                                 {study.participated ? (
                                                     <>
                                                         <MdCheck size={16} style={{ marginRight: '4px' }} />

--- a/src/app/study/StudyModal.tsx
+++ b/src/app/study/StudyModal.tsx
@@ -76,7 +76,15 @@ const StudyModal = ({ isOpen, onClose, study, onApply, onCancelApply, onDelete }
                     </MemberList>
                 </ModalBody>
                 <ModalFooter>
-                    {study.participated ? (
+                    {study.mine && (
+                        <ApplyButton
+                            onClick={(e) => onDelete(study.studyCardId, e)}
+                            style={{ backgroundColor: '#F87171', color: '#FFFFFF' }}
+                        >
+                            삭제하기
+                        </ApplyButton>
+                    )}
+                    {!study.mine && (study.participated ? (
                         <ApplyButton
                             onClick={() => onCancelApply(study.id)}
                         >
@@ -95,7 +103,7 @@ const StudyModal = ({ isOpen, onClose, study, onApply, onCancelApply, onDelete }
                         >
                             {isApplyDisabled ? '모집이 완료된 스터디입니다' : '신청하기'}
                         </ApplyButton>
-                    )}
+                    ))}
                 </ModalFooter>
             </ModalWrapper>
         </ModalContainer>

--- a/src/app/study/StudyModal.tsx
+++ b/src/app/study/StudyModal.tsx
@@ -15,7 +15,7 @@ import {
     MemberListTitle,
     MemberListItems,
     MemberItem,
-    StudyDescription,
+    StudyContent,
     ApplyButton,
 } from './page.style';
 
@@ -25,7 +25,7 @@ interface StudyModalProps {
     study: Study | null;
     onApply: (studyId: string) => void;
     onCancelApply: (studyId: string) => void;
-    onDelete: (studyCardId: string, event?: React.MouseEvent) => Promise<void>; // 삭제 핸들러 추가
+    onDelete: (studyCardId: string, event?: React.MouseEvent) => Promise<void>;
 }
 
 const StudyModal = ({ isOpen, onClose, study, onApply, onCancelApply, onDelete }: StudyModalProps) => {
@@ -63,7 +63,7 @@ const StudyModal = ({ isOpen, onClose, study, onApply, onCancelApply, onDelete }
                     </ModalCloseButton>
                 </ModalHeader>
                 <ModalBody>
-                    <StudyDescription>{study.description}</StudyDescription>
+                    <StudyContent>{study.content}</StudyContent>
                     <MemberList>
                         <MemberListTitle>모집된 회원 ({study.members.length}명)</MemberListTitle>
                         <MemberListItems>

--- a/src/app/study/StudyModal.tsx
+++ b/src/app/study/StudyModal.tsx
@@ -81,7 +81,7 @@ const StudyModal = ({ isOpen, onClose, study, onApply, onCancelApply, onDelete }
                             onClick={(e) => onDelete(study.studyCardId, e)}
                             style={{ backgroundColor: '#F87171', color: '#FFFFFF' }}
                         >
-                            삭제하기
+                            스터디 모집 취소
                         </ApplyButton>
                     )}
                     {!study.mine && (study.participated ? (

--- a/src/app/study/page.style.ts
+++ b/src/app/study/page.style.ts
@@ -5,7 +5,7 @@ import {
     Footer,
     ButtonContent,
 } from "../page.style";
-import { StudyStatusType } from '@/types/study/study';
+import {StudyStatusType, StudyType} from '@/types/study/study';
 
 export const colors = {
     primary: {
@@ -296,13 +296,13 @@ export const TagsContainer = styled.div`
     gap: 0.5rem;
 `;
 
-export const StudyTypeTag = styled.span<{ type: 'certificate' | 'hobby' }>`
+export const StudyTypeTag = styled.span<{ type: StudyType }>`
     font-size: 0.75rem;
     font-weight: 500;
     padding: 0.25rem 0.75rem;
     border-radius: 9999px;
-    background-color: ${props => props.type === 'certificate' ? colors.secondary.light : colors.cardColors.purple.color + '20'};
-    color: ${props => props.type === 'certificate' ? colors.secondary.dark : colors.cardColors.purple.color};
+    background-color: ${props => props.type === StudyType.CERTIFICATE ? colors.secondary.light : colors.cardColors.purple.color + '20'};
+    color: ${props => props.type === StudyType.CERTIFICATE ? colors.secondary.dark : colors.cardColors.purple.color};
 `;
 
 export const OnlineTag = styled.span<{ isOnline: boolean }>`
@@ -430,7 +430,7 @@ export const MemberItem = styled.div`
     color: ${colors.neutral[700]};
 `;
 
-export const StudyDescription = styled.p`
+export const StudyContent = styled.p`
     font-size: 0.9375rem;
     line-height: 1.6;
     color: ${colors.neutral[700]};

--- a/src/components/StudyCreateModal/StudyCreateModal.tsx
+++ b/src/components/StudyCreateModal/StudyCreateModal.tsx
@@ -31,11 +31,10 @@ import {
   ReadOnlyDateDisplay
 } from './StudyCreateModal.style';
 import DatePicker from '@/components/DatePicker/DatePicker';
-import { createStudy } from '@/api/study/createStudyApi';
 import { useToast } from '@/hooks/useToast';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
-import { StudyType, studyTypeToApiCategory } from '@/types/study/study';
+import { StudyType } from '@/types/study/study';
 
 interface StudyCreateModalProps {
   isOpen: boolean;
@@ -46,7 +45,7 @@ interface StudyCreateModalProps {
 
 export interface StudyFormData {
   title: string;
-  description: string;
+  content: string;
   type: StudyType;
   isOnline: boolean;
   totalMembers: number;
@@ -62,7 +61,7 @@ const StudyCreateModal = ({ isOpen, onClose, onSave, onSuccess }: StudyCreateMod
 
   const initialFormData: StudyFormData = {
     title: '',
-    description: '',
+    content: '',
     type: StudyType.CERTIFICATE,
     isOnline: true,
     totalMembers: 5,
@@ -148,7 +147,7 @@ const StudyCreateModal = ({ isOpen, onClose, onSave, onSuccess }: StudyCreateMod
   const handleTypeChange = (value: string) => {
     setFormData(prev => ({
       ...prev,
-      type: value === 'certificate' ? StudyType.CERTIFICATE : StudyType.HOBBY
+      type: value as StudyType
     }));
     setTouched((prev) => ({ ...prev, type: true }));
     validateField('type', value);
@@ -186,13 +185,13 @@ const StudyCreateModal = ({ isOpen, onClose, onSave, onSuccess }: StudyCreateMod
           delete newErrors.totalMembers;
         }
         break;
-      case 'description':
+      case 'content':
         if (!value.trim()) {
-          newErrors.description = '스터디 내용을 입력해주세요';
+          newErrors.content = '스터디 내용을 입력해주세요';
         } else if (value.length > 1000) {
-          newErrors.description = '스터디 내용은 최대 1000자까지 입력 가능합니다';
+          newErrors.content = '스터디 내용은 최대 1000자까지 입력 가능합니다';
         } else {
-          delete newErrors.description;
+          delete newErrors.content;
         }
         break;
       default:
@@ -241,11 +240,11 @@ const StudyCreateModal = ({ isOpen, onClose, onSave, onSuccess }: StudyCreateMod
       isValid = false;
     }
 
-    if (!formData.description.trim()) {
-      newErrors.description = '스터디 내용을 입력해주세요';
+    if (!formData.content.trim()) {
+      newErrors.content = '스터디 내용을 입력해주세요';
       isValid = false;
-    } else if (formData.description.length > 1000) {
-      newErrors.description = '스터디 내용은 최대 1000자까지 입력 가능합니다';
+    } else if (formData.content.length > 1000) {
+      newErrors.content = '스터디 내용은 최대 1000자까지 입력 가능합니다';
       isValid = false;
     }
 
@@ -341,7 +340,7 @@ const StudyCreateModal = ({ isOpen, onClose, onSave, onSuccess }: StudyCreateMod
                         id="certificate"
                         name="type"
                         checked={formData.type === StudyType.CERTIFICATE}
-                        onChange={() => handleTypeChange('certificate')}
+                        onChange={() => handleTypeChange(StudyType.CERTIFICATE)}
                     />
                     <RadioLabel htmlFor="certificate">자격증</RadioLabel>
                   </RadioOption>
@@ -351,7 +350,7 @@ const StudyCreateModal = ({ isOpen, onClose, onSave, onSuccess }: StudyCreateMod
                         id="hobby"
                         name="type"
                         checked={formData.type === StudyType.HOBBY}
-                        onChange={() => handleTypeChange('hobby')}
+                        onChange={() => handleTypeChange(StudyType.HOBBY)}
                     />
                     <RadioLabel htmlFor="hobby">취미</RadioLabel>
                   </RadioOption>
@@ -429,23 +428,23 @@ const StudyCreateModal = ({ isOpen, onClose, onSave, onSuccess }: StudyCreateMod
             </FormGroup>
 
             <FormGroup>
-              <FormLabel htmlFor="description">스터디 내용</FormLabel>
+              <FormLabel htmlFor="content">스터디 내용</FormLabel>
               <InputContainer>
                 <TextArea
-                    id="description"
-                    name="description"
-                    value={formData.description}
+                    id="content"
+                    name="content"
+                    value={formData.content}
                     onChange={handleChange}
                     placeholder="스터디 진행 방식, 일정, 목표 등을 설명해주세요"
                     maxLength={1000}
                     style={{
-                      borderColor: touched.description && errors.description ? '#f56565' : undefined
+                      borderColor: touched.content && errors.content ? '#f56565' : undefined
                     }}
                 />
               </InputContainer>
               <MessageContainer>
-                {touched.description && errors.description && <ErrorMessage>{errors.description}</ErrorMessage>}
-                <CharCount>{formData.description.length}/1000</CharCount>
+                {touched.content && errors.content && <ErrorMessage>{errors.content}</ErrorMessage>}
+                <CharCount>{formData.content.length}/1000</CharCount>
               </MessageContainer>
             </FormGroup>
             <ButtonContainer>

--- a/src/types/study/study.ts
+++ b/src/types/study/study.ts
@@ -6,70 +6,8 @@ export enum StudyStatusType {
 export type StudyFilterStatusType = StudyStatusType | 'all';
 
 export enum StudyType {
-  CERTIFICATE = 'certificate',
-  HOBBY = 'hobby'
-}
-
-export type ApiStudyCategory = 'CERTIFICATE' | 'HOBBY';
-
-// StudyType을 API 카테고리로 변환하는 함수
-export function studyTypeToApiCategory(type: StudyType): ApiStudyCategory {
-  switch(type) {
-    case StudyType.CERTIFICATE:
-      return 'CERTIFICATE';
-    case StudyType.HOBBY:
-      return 'HOBBY';
-    default:
-      throw new Error(`Invalid study type: ${type}`);
-  }
-}
-
-// API 카테고리를 StudyType으로 변환하는 함수
-export function apiCategoryToStudyType(category: ApiStudyCategory): StudyType {
-  switch(category) {
-    case 'CERTIFICATE':
-      return StudyType.CERTIFICATE;
-    case 'HOBBY':
-      return StudyType.HOBBY;
-    default:
-      throw new Error(`Invalid API category: ${category}`);
-  }
-}
-
-// 문자열을 StudyType으로 변환하는 유틸리티 함수
-export function parseStudyType(typeString: string): StudyType {
-  switch(typeString.toLowerCase()) {
-    case 'certificate':
-      return StudyType.CERTIFICATE;
-    case 'hobby':
-      return StudyType.HOBBY;
-    default:
-      throw new Error(`Invalid study type: ${typeString}`);
-  }
-}
-
-// StudyType을 표시 텍스트로 변환하는 함수
-export function getStudyTypeDisplayText(type: StudyType): string {
-  switch(type) {
-    case StudyType.CERTIFICATE:
-      return '자격증';
-    case StudyType.HOBBY:
-      return '취미';
-    default:
-      return '알 수 없음';
-  }
-}
-
-// StudyStatusType을 표시 텍스트로 변환하는 함수
-export function getStudyStatusDisplayText(status: StudyStatusType): string {
-  switch(status) {
-    case StudyStatusType.RECRUITING:
-      return '모집 중';
-    case StudyStatusType.COMPLETED:
-      return '모집 완료';
-    default:
-      return '알 수 없음';
-  }
+  CERTIFICATE = 'CERTIFICATE',
+  HOBBY = 'HOBBY'
 }
 
 // 멤버 타입
@@ -89,20 +27,21 @@ export interface StudyAuthor {
 export interface Study {
   id: string;
   studyCardId: string;
-  status: StudyStatusType;
-  type: StudyType;
-  isOnline: boolean;
-  author: StudyAuthor;
   title: string;
-  description: string;
-  mine: boolean;
-  currentMembers: number;
+  content: string;
+  author: StudyAuthor;
   totalMembers: number;
   startDate: string;
+  type: StudyType;
   deadline: string;
-  members: StudyMember[];
-  isApplied: boolean;
+  isOnline: boolean;
+  status: StudyStatusType;
+  participantIds: string[];
+  participantNames: string[];
   participated: boolean;
+  mine: boolean;
+  currentMembers: number;
+  members: StudyMember[];
 }
 
 // 스터디 필터 인터페이스

--- a/src/utils/studyAdapter.ts
+++ b/src/utils/studyAdapter.ts
@@ -10,23 +10,28 @@ export const adaptStudyCardToStudy = (studyCard: StudyCardItem): Study => {
   return {
     id: studyCard.studyCardId,
     studyCardId: studyCard.studyCardId,
-    status: studyCard.available ? StudyStatusType.RECRUITING : StudyStatusType.COMPLETED,
-    type: studyCard.type,
-    isOnline: studyCard.online,
-    author: {
-      id: studyCard.userProfile.username, // 실제 id가 없으므로 username을 id로 사용
-      name: studyCard.userProfile.username,
-      profileImage: studyCard.userProfile.profileImageUrl || 'https://randomuser.me/api/portraits/men/32.jpg' // 기본 이미지 제공
-    },
     title: studyCard.title,
-    description: studyCard.content,
-    mine: studyCard.mine,
-    currentMembers: 1, // API에서 제공하지 않음, 기본값 설정
-    totalMembers: 10, // API에서 제공하지 않음, 기본값 설정
-    startDate: new Date().toISOString().split('T')[0], // API에서 제공하지 않음, 현재 날짜로 설정
+    content: studyCard.content,
+    author: {
+      id: studyCard.userProfile.username, // id 넘어오지 않고있음. 따라서 username을 id로 사용
+      name: studyCard.userProfile.username,
+      profileImage: studyCard.userProfile.profileImageUrl || 'https://placehold.co/600x400?text=user'
+    },
+    totalMembers: studyCard.maxParticipants,
+    startDate: studyCard.createdTime.split('T')[0],
+    type: studyCard.category,
     deadline: studyCard.dueDate,
-    members: [{ id: studyCard.userProfile.username, name: studyCard.userProfile.username }], // 작성자만 멤버로 추가
-    isApplied: studyCard.registered,
-    participated: studyCard.participated
+    isOnline: studyCard.online,
+    status: studyCard.available ? StudyStatusType.RECRUITING : StudyStatusType.COMPLETED,
+    participantIds: studyCard.participantIds || [],
+    participantNames: studyCard.participantNames || [],
+    participated: studyCard.participated,
+    mine: studyCard.mine,
+    currentMembers: studyCard.participantNames.length,
+
+    members: studyCard.participantIds.map((id, index) => ({
+        id,
+        name: studyCard.participantNames[index] || '알 수 없는 사용자',
+    })),
   };
 };


### PR DESCRIPTION
closed #34 

## 테스트 완료
<img width="655" height="599" alt="스크린샷 2025-08-17 16 29 13" src="https://github.com/user-attachments/assets/6ea1d782-3d79-4b09-a498-24ae2bafab86" />

## 신청한 사용자 입장
<img width="530" height="343" alt="스크린샷 2025-08-17 16 29 28" src="https://github.com/user-attachments/assets/a2f1cc21-f710-4448-8522-e02bd0e303ee" />

## 카드를 생성한 생성인 입장
<img width="520" height="338" alt="스크린샷 2025-08-17 16 35 35" src="https://github.com/user-attachments/assets/02efe296-3dfe-4d29-b7bf-9ae26c866032" />


## 신청이 완료된 카드를 보는 외부인 입장
<img width="521" height="338" alt="스크린샷 2025-08-17 16 34 50" src="https://github.com/user-attachments/assets/d09ca40f-fe62-4e37-807a-6f8a2456cd92" />

